### PR TITLE
Adds DAP reporting, and forceSSL flag

### DIFF
--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -196,8 +196,13 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 ga('create', '{{ site.google_analytics_id }}', 'auto');
 ga('set', 'anonymizeIp', true);
+ga('set', 'forceSSL', true);
 ga('send', 'pageview');
 </script>
 {% endif %}
+
+<!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->
+<script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOI"></script>
+
 </body>
 </html>


### PR DESCRIPTION
This adds a DAP embed code of:

```
<script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOI"></script>
```

It specifies `DOI` as the `agency` field, but if there's a better agency to declare as the owner, by all means.

This takes advantage of the DAP's new [centrally hosted JavaScript code](https://www.digitalgov.gov/2015/08/14/secure-central-hosting-for-the-digital-analytics-program/), which means 18f.gsa.gov will automatically get security updates, new features, and other bugfixes automatically.
